### PR TITLE
Forcing XMLRPC decoders to UTF-8 encoding

### DIFF
--- a/src/Ripcord/Client/Client.php
+++ b/src/Ripcord/Client/Client.php
@@ -184,7 +184,7 @@ class Client
         }
         $request = xmlrpc_encode_request($name, $args, $this->_outputOptions);
         $response = $this->_transport->post($this->_url, $request);
-        $result = xmlrpc_decode($response);
+        $result = xmlrpc_decode($response, 'utf-8');
         $this->_rootClient->_request = $request;
         $this->_rootClient->_response = $response;
         if (Ripcord::isFault($result) && $this->_throwExceptions) {

--- a/src/Ripcord/Server/Server.php
+++ b/src/Ripcord/Server/Server.php
@@ -216,7 +216,7 @@ class Server
         }
         $method = null;
         ob_start(); // xmlrpc_decode echo expat errors if the xml is not valid, can't stop it.
-        $params = xmlrpc_decode_request($request_xml, $method);
+        $params = xmlrpc_decode_request($request_xml, $method, 'utf-8');
         ob_end_clean(); // clean up any xml errors
         return ['methodName' => $method, 'params' => $params];
     }
@@ -314,7 +314,7 @@ class Server
                 $req = xmlrpc_encode_request($method, $args, $this->outputOptions);
                 $result = xmlrpc_server_call_method($this->xmlrpc, $req, null, $this->outputOptions);
 
-                return xmlrpc_decode($result);
+                return xmlrpc_decode($result, 'utf-8');
             } else {
                 throw new BadMethodCallException(
                     'Method '.$method.' not found.',


### PR DESCRIPTION
This should solve the problem where UTF-8 encoded data returned from the RPC gets garbled after decoding (#2)
