### PR TITLE
Use single curl resource for class

### DIFF
--- a/src/Ripcord/Client/Transport/Curl.php
+++ b/src/Ripcord/Client/Transport/Curl.php
@@ -12,6 +12,11 @@ use Ripcord\Ripcord;
 class Curl implements Transport
 {
     /**
+     * The curl handle
+     */
+    private $curl;
+    
+    /**
      * A list of CURL options.
      */
     private $options = [];
@@ -54,7 +59,10 @@ class Curl implements Transport
      */
     public function post($url, $request)
     {
-        $curl = curl_init();
+        if (!$this->curl) {
+            $this->curl = curl_init();
+        }
+        curl_reset($this->curl);
         $options = (array) $this->options + [
                 CURLOPT_RETURNTRANSFER => 1,
                 CURLOPT_URL            => $url,
@@ -62,16 +70,15 @@ class Curl implements Transport
                 CURLOPT_POSTFIELDS     => $request,
                 CURLOPT_HEADER         => true,
             ];
-        curl_setopt_array($curl, $options);
-        $contents = curl_exec($curl);
-        $headerSize = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
+        curl_setopt_array($this->curl, $options);
+        $contents = curl_exec($this->curl);
+        $headerSize = curl_getinfo($this->curl, CURLINFO_HEADER_SIZE);
         $this->responseHeaders = substr($contents, 0, $headerSize);
         $contents = substr($contents, $headerSize);
 
-        if (curl_errno($curl)) {
-            $errorNumber = curl_errno($curl);
-            $errorMessage = curl_error($curl);
-            curl_close($curl);
+        if (curl_errno($this->curl)) {
+            $errorNumber = curl_errno($this->curl);
+            $errorMessage = curl_error($this->curl);
             $version = explode('.', phpversion());
             if (!$this->skipPreviousException) { // previousException supported in php >= 5.3
                 $exception = new TransportException(
@@ -87,8 +94,13 @@ class Curl implements Transport
             }
             throw $exception;
         }
-        curl_close($curl);
 
         return $contents;
+    }
+    
+    public function __destruct() {
+        if ($this->curl) {
+            curl_close($this->curl);
+        }
     }
 }


### PR DESCRIPTION
It turns out the issue I mentioned in #9 was caused by the library. The library currently creates a new `curl` handle for every request. I used netstat and noticed that there were tons of connections in my connection table, which was causing the server to be sluggish and ultimately hang, lag, and drop calls.

This PR ensures that a single curl handle is used per `Ripcord\Client\Transport\Curl` instance. As soon as I changed this my script sped up massively and I don't receive any weird SSL errors or hanging connections (the hanging connections was another related issue taking place that I didn't mention previously).