### PR TITLE
Add ability to edit transport options from client

### DIFF
--- a/src/Ripcord/Client/Client.php
+++ b/src/Ripcord/Client/Client.php
@@ -256,4 +256,18 @@ class Client
 
         return $result;
     }
+
+    public function getTransportOptions()
+    {
+        if (isset($this->_transport)) {
+            return $this->_transport->getOptions();
+        }
+    }
+
+    public function setTransportOptions(array $options = [])
+    {
+        if (isset($this->_transport)) {
+            $this->_transport->setOptions($options);
+        }
+    }
 }

--- a/src/Ripcord/Client/Transport/Curl.php
+++ b/src/Ripcord/Client/Transport/Curl.php
@@ -91,4 +91,16 @@ class Curl implements Transport
 
         return $contents;
     }
+    
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    public function setOptions($curlOptions = null)
+    {
+        if (isset($curlOptions)) {
+            $this->options = $curlOptions;
+        }
+    }
 }


### PR DESCRIPTION
I recently had a need to update the client's transport options after it has been instantiated. I'm using the Curl transport, so that's the one I edited, but this could easily be added to the Stream transport as well.