### PR TITLE
Add content-type header to curl transport

### DIFF
--- a/src/Ripcord/Client/Transport/Curl.php
+++ b/src/Ripcord/Client/Transport/Curl.php
@@ -69,7 +69,7 @@ class Curl implements Transport
             CURLOPT_POST           => true,
             CURLOPT_POSTFIELDS     => $request,
             CURLOPT_HEADER         => true,
-            CURLOPT_HTTPHEADER => ['Content-Type: text/xml'],
+            CURLOPT_HTTPHEADER     => ['Content-Type: text/xml'],
         ];
         curl_setopt_array($this->curl, $options);
         $contents = curl_exec($this->curl);

--- a/src/Ripcord/Client/Transport/Curl.php
+++ b/src/Ripcord/Client/Transport/Curl.php
@@ -69,6 +69,7 @@ class Curl implements Transport
             CURLOPT_POST           => true,
             CURLOPT_POSTFIELDS     => $request,
             CURLOPT_HEADER         => true,
+            CURLOPT_HTTPHEADER => ['Content-Type: text/xml'],
         ];
         curl_setopt_array($this->curl, $options);
         $contents = curl_exec($this->curl);


### PR DESCRIPTION
I was working on upgrading my Odoo account from v10 to v13. All of the RPC calls started failing with `xml.parsers.expat.ExpatError: no element found: line 1, column 0`. I'm using the Curl transport, and was able to trace the problem down to the fact that no content-type header is being set, which must cause Odoo to think no XML data is being sent in the request.

This fixes it.