### PR TITLE
Add Timeout Handling for XML-RPC Requests

### DIFF
--- a/src/Ripcord/Client/Transport/Stream.php
+++ b/src/Ripcord/Client/Transport/Stream.php
@@ -63,7 +63,7 @@ class Stream implements Transport
             if (isset($error['message']) && strpos($error['message'], 'timed out') !== false) {
                 throw new TransportException(
                     sprintf(
-                        'Connection timed out after %s second(s)', 
+                        'Connection timed out after %s second(s)',
                         $options['http']['timeout'] ?: 'x'
                     ),
                     Ripcord::CONNECTION_TIMEOUT

--- a/src/Ripcord/Client/Transport/Stream.php
+++ b/src/Ripcord/Client/Transport/Stream.php
@@ -58,7 +58,14 @@ class Stream implements Transport
         $context = stream_context_create($options);
         $result = file_get_contents($url, false, $context);
         //$this->responseHeaders = $http_response_header;
-        if (!$result) {
+        if ($result === false) {
+            $error = error_get_last();
+            if ($error && strpos($error['message'], 'timed out') !== false) {
+                throw new TransportException(
+                    'Connection timed out after ' . $options['http']['timeout'] . ' second(s)',
+                    Ripcord::CONNECTION_TIMEOUT
+                );
+            }
             throw new TransportException(
                 'Could not access '.$url,
                 Ripcord::CANNOT_ACCESS_URL

--- a/src/Ripcord/Client/Transport/Stream.php
+++ b/src/Ripcord/Client/Transport/Stream.php
@@ -60,9 +60,12 @@ class Stream implements Transport
         //$this->responseHeaders = $http_response_header;
         if ($result === false) {
             $error = error_get_last();
-            if ($error && strpos($error['message'], 'timed out') !== false) {
+            if (isset($error['message']) && strpos($error['message'], 'timed out') !== false) {
                 throw new TransportException(
-                    'Connection timed out after '.$options['http']['timeout'].' second(s)',
+                    sprintf(
+                        'Connection timed out after %s second(s)', 
+                        $options['http']['timeout'] ?: 'x'
+                    ),
                     Ripcord::CONNECTION_TIMEOUT
                 );
             }

--- a/src/Ripcord/Client/Transport/Stream.php
+++ b/src/Ripcord/Client/Transport/Stream.php
@@ -62,10 +62,11 @@ class Stream implements Transport
             $error = error_get_last();
             if ($error && strpos($error['message'], 'timed out') !== false) {
                 throw new TransportException(
-                    'Connection timed out after ' . $options['http']['timeout'] . ' second(s)',
+                    'Connection timed out after '.$options['http']['timeout'].' second(s)',
                     Ripcord::CONNECTION_TIMEOUT
                 );
             }
+
             throw new TransportException(
                 'Could not access '.$url,
                 Ripcord::CANNOT_ACCESS_URL

--- a/src/Ripcord/Client/Transport/Stream.php
+++ b/src/Ripcord/Client/Transport/Stream.php
@@ -62,10 +62,11 @@ class Stream implements Transport
             $error = error_get_last();
             if ($error && strpos($error['message'], 'timed out') !== false) {
                 throw new TransportException(
-                    'Connection timed out after ' . $options['http']['timeout'] . ' second(s)',
+                    'Connection timed out after '.$options['http']['timeout'].' second(s)',
                     Ripcord::CONNECTION_TIMEOUT
                 );
             }
+            
             throw new TransportException(
                 'Could not access '.$url,
                 Ripcord::CANNOT_ACCESS_URL

--- a/src/Ripcord/Ripcord.php
+++ b/src/Ripcord/Ripcord.php
@@ -47,6 +47,10 @@ class Ripcord
      * Variable is not a class name or an object - Thrown by the ripcord server.
      */
     const UNKNOWN_SERVICE_TYPE = -8;
+    /**
+     * Connection Timeout - Thrown by the ripcord Stream.
+     */
+    const CONNECTION_TIMEOUT = 408; // HTTP 408 Request Timeout
 
     /**
      *  This method checks whether the given argument is an XML-RPC fault.
@@ -124,7 +128,7 @@ class Ripcord
     public static function client($url, $options = null, $transport = null)
     {
         if (!isset($transport)) {
-            $transport = new Stream();
+            $transport = new Stream($options);
         }
 
         return new Client($url, $options, $transport);


### PR DESCRIPTION
- Added CONNECTION_TIMEOUT constant (408) to Ripcord.
- Updated Stream transport to accept and apply timeout settings from $options.
- Implemented explicit timeout detection in Stream::post(), throwing a TransportException with Ripcord::CONNECTION_TIMEOUT if a request exceeds the timeout duration.
- Prevents indefinite hangs by ensuring unresponsive connections fail with a clear error.

This hopefully improves reliability for applications using Ripcord by allowing configurable timeouts and providing proper error handling for network delays.